### PR TITLE
allow stream response as string or as resource

### DIFF
--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -56,6 +56,16 @@ trait Exportable
     }
 
     /**
+     * @param  bool  $asString
+     *
+     * @return mixed
+     */
+    public function stream(bool $asString = false): mixed
+    {
+        return CsvExporter::stream($this, $asString);
+    }
+
+    /**
      * @param string|null $filename
      * @param string|null $disk
      * @param array $diskOptions

--- a/src/CsvExporter.php
+++ b/src/CsvExporter.php
@@ -86,6 +86,23 @@ class CsvExporter
     }
 
     /**
+     * @param  object  $exportable
+     * @param  bool  $asString
+     *
+     * @throws InvalidCellValueException
+     */
+    public function stream(object $exportable, bool $asString = false)
+    {
+        $streamResponse = $this->service->stream($exportable);
+
+        if ($asString) {
+            return stream_get_contents($streamResponse);
+        }
+
+        return $streamResponse;
+    }
+
+    /**
      * @param object $exportable
      * @param string $filename
      * @param string|null $disk

--- a/src/Services/ExportableService.php
+++ b/src/Services/ExportableService.php
@@ -120,6 +120,16 @@ class ExportableService
     }
 
     /**
+     * @param  object  $exportable
+     *
+     * @throws InvalidCellValueException
+     */
+    public function stream(object $exportable)
+    {
+        return $this->getStream($exportable);
+    }
+
+    /**
      * @param object $exportable
      * @param string $filename
      * @param string|null $disk


### PR DESCRIPTION
Probably wants some amendments however this will allow a user to get the response as a string or resource for use cases where saving or downloading the file are not required or wanted.